### PR TITLE
Buffer Boundary CRLF Check

### DIFF
--- a/src/Utf8StreamReader/Utf8StreamReader.cs
+++ b/src/Utf8StreamReader/Utf8StreamReader.cs
@@ -127,7 +127,7 @@ public sealed class Utf8StreamReader : IAsyncDisposable, IDisposable
                 return true;
             }
 
-            lastNewLinePosition = lastExaminedPosition = -2; // not exists new line in this bufer
+            lastNewLinePosition = lastExaminedPosition = -2; // not exists new line in this buffer
             line = default;
             return false;
         }
@@ -224,11 +224,13 @@ public sealed class Utf8StreamReader : IAsyncDisposable, IDisposable
                 }
 
                 // scan examined(already scanned) to End.
-                var index = IndexOfNewline(inputBuffer.AsSpan(examined, positionEnd - examined), out var examinedIndex);
+                // Back one index to check if CRLF fell on buffer boundary
+                var scanFrom = examined > 0 ? examined - 1 : examined;
+                var index = IndexOfNewline(inputBuffer.AsSpan(scanFrom, positionEnd - scanFrom), out var examinedIndex);
                 if (index != -1)
                 {
-                    lastNewLinePosition = examined + index;
-                    lastExaminedPosition = examined + examinedIndex;
+                    lastNewLinePosition = scanFrom + index;
+                    lastExaminedPosition = scanFrom + examinedIndex;
                     return true;
                 }
 

--- a/tests/Utf8StreamReader.Tests/Tests.cs
+++ b/tests/Utf8StreamReader.Tests/Tests.cs
@@ -361,6 +361,29 @@ baz boz too
         }
     }
 
+    [Fact]
+    public async Task NewLineTrimmedAtBufferBoundary()
+    {
+        // Buffer 1: aaa....\r\nasdf\r
+        // Buffer 2: \nasdf
+        var ms2 = CreateStringStream(
+            new string('a', 1017) +
+            "\r\nasdf" +
+            "\r\nasdf");
+
+        var actual = await Utf8StreamReaderResultAsync(ms2, 1024);
+
+        string[] expected =
+        [
+            new string('a', 1017),
+            "asdf",
+            "asdf",
+        ];
+
+        actual[1].Should().Be(expected[1]);
+        actual.Should().Equal(expected);
+    }
+
     static async Task<string[]> Utf8StreamReaderResultAsync(Stream ms, int? size = null)
     {
         var reader = (size == null) ? new Utf8StreamReader(ms) : new Utf8StreamReader(ms, size.Value);


### PR DESCRIPTION
If the buffer reads in up to a CR and the following buffer read starts with an LF, the CR was being left on the end of the first line returned after the second buffer was read. Adjust index check to account for this

Closes https://github.com/Cysharp/Utf8StreamReader/issues/4
